### PR TITLE
Normaliza `Item` entre diferentes tipos de endpoints

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -203,6 +203,7 @@ type Item struct {
 	PictureUrl  string  `json:"picture_url,omitempty"`
 	CategoryId  string  `json:"category_id,omitempty"`
 	Quantity    int64   `json:"quantity,omitempty"`
+	CurrencyId  string  `json:"currency_id,omitempty"`
 	UnitPrice   float64 `json:"unit_price,omitempty"`
 }
 


### PR DESCRIPTION
Adicionado um campo `CurrencyId` ao `Item`.

Quando utilizado no [payment](https://www.mercadopago.com.br/developers/en/reference/payments/resource/) o `items` (dentro de `additional_info`) não utiliza `currency_id`.

Porém quando no `items` de [preferences](https://www.mercadopago.com.br/developers/en/reference/preferences/resource/) é utilizado campo `currency_id`.

Essa alteração não quebra o comportamento anterior de pagamentos já que quando o campo não está presente o mesmo é ignorado.

Também existe a possibilidade de separar os itens, similar o que é feito na biblioteca oficial em java [preferences](https://github.com/mercadopago/dx-java/blob/master/src/main/java/com/mercadopago/resources/datastructures/preference/Item.java) vs [payment](https://github.com/mercadopago/dx-java/blob/master/src/main/java/com/mercadopago/resources/datastructures/payment/Item.java).

Porém não acho que seja possível atualmente (teria que ser criado uma estrutura diferente de pastas).

Vale notar que futuramente será necessário a distinção entre os tipos e talvez até reestruturação do projeto para poder implementar mais métodos de pagamentos, principalmente pelo fato do `Payer` utilizado em `Payments` ser bem diferente do `Payer` utilizado em `Preferences`, uma alternativa seria fazer estruturas compatíveis com os dois endpoints (similar o que é feito na biblioteca oficial em [PHP](https://github.com/mercadopago/dx-php/blob/299178d882e81d4684e9f3fd274b5f28016421c9/src/MercadoPago/Entities/Shared/Payer.php#L29)).
 
