### PR TITLE
Adds custom http client

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,5 +1,7 @@
 package mp
 
+import "net/http"
+
 const oauthTokenPath = "/oauth/token"
 
 type Client struct {
@@ -7,6 +9,7 @@ type Client struct {
 	ClientSecret string
 	PublicKey    string
 	AuthToken    AuthToken
+	httpClient   *http.Client
 }
 
 type AuthToken struct {
@@ -28,6 +31,7 @@ func NewClient(id, secret, key, token string) *Client {
 		AuthToken: AuthToken{
 			AccessToken: token,
 		},
+		httpClient: http.DefaultClient,
 	}
 
 }

--- a/methods.go
+++ b/methods.go
@@ -65,7 +65,7 @@ func (c *Client) execute(method string, path string, params interface{}, headers
 		}
 	}
 
-	response, err := http.DefaultClient.Do(request)
+	response, err := c.httpClient.Do(request)
 	if err != nil {
 		return err
 	}
@@ -108,4 +108,8 @@ func (c *Client) Put(path string, params interface{}, headers Headers, model int
 // Execute DELETE requests
 func (c *Client) Delete(path string, params interface{}, headers Headers, model interface{}) error {
 	return c.execute("DELETE", path, params, headers, model)
+}
+
+func (c *Client) SetHttpClient(httpClient *http.Client) {
+	c.httpClient = httpClient
 }


### PR DESCRIPTION
Adiciona a opção de informar um `http.Client`.

Por padrão o `http.DefaultClient` não possui um timeout definido, o que pode fazer o mesmo "travar" em certos casos.

Essa implementação não quebra a compatibilidade, já que na criação de um novo `Client` é definido o `http.DefaultClient` como padrão.
